### PR TITLE
Adding Snakefmt instead of Snakemake lint

### DIFF
--- a/.github/workflows/test-snake.yml
+++ b/.github/workflows/test-snake.yml
@@ -16,15 +16,20 @@ jobs:
         poetry-version: ["1.8.3"]
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter/slim@v5
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: branch_name
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          DISABLE_ERRORS: true
+          PYTHON_FLAKE8_CONFIG_FILE: .flake8
+          VALIDATE_PYTHON_FLAKE8: true
           VALIDATE_SNAKEMAKE_SNAKEFMT: true
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test-snake.yml
+++ b/.github/workflows/test-snake.yml
@@ -16,7 +16,7 @@ jobs:
         poetry-version: ["1.8.3"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
 
       - name: Lint Code Base
         uses: github/super-linter@v3

--- a/.github/workflows/test-snake.yml
+++ b/.github/workflows/test-snake.yml
@@ -17,6 +17,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          VALIDATE_SNAKEMAKE_SNAKEFMT: true
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -35,11 +45,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
-
-      - name: Snakemake Linting
-        run: |
-          cd workflow
-          snakemake --lint -s Snakefile
 
       - name: Snakemake Testing
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,15 +28,12 @@ repos:
         language: node
         pass_filenames: true
         types: [python]
+  - repo: https://github.com/snakemake/snakefmt
+    rev: v0.10.2 
+    hooks:
+      - id: snakefmt
   - repo: local
     hooks:
-      - id: snakemake-lint
-        name: Snakemake Lint
-        entry: bash -c 'cd workflow && snakemake --lint'
-        language: system
-        files: (Snakefile|\.smk$)
-        pass_filenames: false
-
       - id: snakemake-dryrun
         name: Snakemake Dry Run
         entry: bash -c 'cd workflow && snakemake -n'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ mkdocstrings = {extras = ["python"], version = "^0.21.2"}
 mkdocs-gen-files = "^0.4.0"
 mkdocs-literate-nav = "^0.6.0"
 setuptools = "^74.1.2"
+snakefmt = "^0.10.2"
 
 [tool.coverage.report]
 fail_under = 85.0
@@ -56,6 +57,10 @@ exclude = ["**/node_modules",
     "src/experimental",
     "src/typestubs"
 ]
+
+[tool.snakefmt]
+line_length = 88
+include = '\.smk$|^Snakefile'
 
 
 [build-system]


### PR DESCRIPTION
Snakemake lint does not allow for ignores, hence the switch.